### PR TITLE
Adds acorn as a dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "@rollup/pluginutils": "^4.2.0",
+    "acorn": "^8.7.1",
     "acorn-import-assertions": "git+http://github.com/swiing/acorn-import-assertions.git",
     "estree-walker": "^2.0.2"
   },


### PR DESCRIPTION
When I installed and attempted to use this, I got an error about it being unable to find the module 'acorn'. This fixes that.

<img width="1120" alt="image" src="https://user-images.githubusercontent.com/157303/174146691-8272d00a-e80b-4c23-87dd-936366d08caf.png">
